### PR TITLE
Fix: Append a newline on every customization content generated

### DIFF
--- a/codeql_bundle/helpers/bundle.py
+++ b/codeql_bundle/helpers/bundle.py
@@ -459,7 +459,7 @@ class CustomBundle(Bundle):
                     f"import {customization_pack.get_module_name()}.Customizations"
                 )
             with pack_copy.get_customizations_module_path().open("w") as fd:
-                fd.writelines(contents)
+                fd.writelines(map(lambda content: content + "\n", contents))
 
             # Remove the original target library pack
             logging.debug(


### PR DESCRIPTION
The current code simply concatenates all contents into a single line of QL code, making it invalid. This fix appends a newline on every `content` of `contents` so that it becomes a valid QL code (though it adds a trailing newline at the end of the final generated code; but that's minor).